### PR TITLE
feat: load `signedurl` filter by default

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -2,29 +2,20 @@
 
 ## Overview
 
-To validate signed URLs we can use build in filter. We can enable it in two simple steps.
+To validate signed URLs we can use build in filter. We can enable it in one simple step.
 
-1. We have to add our filter to the `$aliases` array.
-2. And then define when filter should be fired up. In the example below we will assume it will be used when the first segment of the url will contain `signed-urls` string.
+Define when filter should be fired up. In the example below we will assume it will be used when the first segment of the url will contain `signed-urls` string.
 
 ```php
 // app/Config/Filters.php
 <?php
 
-...
-
-use Michalsn\CodeIgniterSignedUrl\Filters\SignedUrl;
+// ...
 
 class Filters extends BaseConfig
 {
-    ...
 
-    public $aliases = [
-        ...
-        'signedurl' => SignedUrl::class
-    ];
-
-    ...
+    // ...
 
     public $filters = [
         'signedurl' => ['before' => ['signed-urls/*']],
@@ -43,4 +34,4 @@ More info you can find in the [Configuration](configuration.md) page.
 
 !!! note
 
-    Remember, that if the filter implementation doesn't suit you, you can always create your own, which will behave differently upon an error. You can also not use the filter at all and make the check in the controller.
+    Remember, that if the filter implementation doesn't suit you, you can always [create your own](https://codeigniter.com/user_guide/incoming/filters.html?highlight=filter#creating-a-filter), which will behave differently upon an error. You can also not use the filter at all and make the check in the controller.

--- a/src/Config/Registrar.php
+++ b/src/Config/Registrar.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Michalsn\CodeIgniterSignedUrl\Config;
+
+use Michalsn\CodeIgniterSignedUrl\Filters\SignedUrl;
+
+class Registrar
+{
+    /**
+     * Register the CodeIgniterSignedUrl filter.
+     */
+    public static function Filters(): array
+    {
+        return [
+            'aliases' => [
+                'signedurl' => SignedUrl::class,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Hi,
PR helps to reduce one step of the filter usage method.
However, you can safely pass this PR.

Thank you for package.